### PR TITLE
Add Authentication Interceptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ android:
   - platform-tools
   - tools
   - build-tools-23.0.3
-  - android-24
+  - android-25
   - extra-google-m2repository
   - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.novoda:build-properties-plugin:1.2.1'
     }
 }

--- a/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationInterceptor.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationInterceptor.java
@@ -61,7 +61,7 @@ public class AuthenticationInterceptor {
         authenticationService.invalidateAccessToken();
         return Observable.fromCallable(new Callable<Void>() {
             @Override
-            public Void call() throws Exception {
+            public Void call() {
                 return null;
             }
         });
@@ -76,7 +76,7 @@ public class AuthenticationInterceptor {
     }
 
     @AutoValue
-    static abstract class RetryMetadata {
+    abstract static class RetryMetadata {
 
         static RetryMetadata create(Throwable throwable, Integer retry) {
             return new AutoValue_AuthenticationInterceptor_RetryMetadata(throwable, retry);

--- a/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationRetryRule.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationRetryRule.java
@@ -1,0 +1,76 @@
+package jackszm.androiddevtweets.api;
+
+import java.util.concurrent.Callable;
+
+import jackszm.androiddevtweets.api.RequestExecutor.HttpException;
+import rx.Observable;
+import rx.functions.Func1;
+import rx.functions.Func2;
+
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+
+public class AuthenticationRetryRule {
+
+    private static final int RETRY_COUNT = 1;
+    private static final int RETRY_COUNT_PLUS_FINAL_ERROR_EMISSION = RETRY_COUNT + 1;
+
+    private final AuthenticationService authenticationService;
+
+    public AuthenticationRetryRule(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    public Func1<Observable<? extends Throwable>, Observable<?>> rule() {
+        return new Func1<Observable<? extends Throwable>, Observable<?>>() {
+            @Override
+            public Observable<?> call(Observable<? extends Throwable> attempt) {
+                return attempt.zipWith(retryCounts(), tick()).flatMap(checkForAuthenticationErrors());
+            }
+        };
+    }
+
+    private Observable<Integer> retryCounts() {
+        return Observable.range(1, RETRY_COUNT_PLUS_FINAL_ERROR_EMISSION);
+    }
+
+    private Func2<Throwable, Integer, Throwable> tick() {
+        return new Func2<Throwable, Integer, Throwable>() {
+            @Override
+            public Throwable call(Throwable throwable, Integer integer) {
+                return throwable;
+            }
+        };
+    }
+
+    private Func1<Throwable, Observable<?>> checkForAuthenticationErrors() {
+        return new Func1<Throwable, Observable<?>>() {
+            @Override
+            public Observable<?> call(Throwable throwable) {
+                if (isUnauthorized(throwable)) {
+                    return retry();
+                } else {
+                    return doNotRetry(throwable);
+                }
+            }
+        };
+    }
+
+    private Observable<Void> retry() {
+        authenticationService.invalidateAccessToken();
+        return Observable.fromCallable(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                return null;
+            }
+        });
+    }
+
+    private Observable<Throwable> doNotRetry(Throwable throwable) {
+        return Observable.error(throwable);
+    }
+
+    private boolean isUnauthorized(Throwable throwable) {
+        return throwable instanceof HttpException && ((HttpException) throwable).httpCode() == HTTP_UNAUTHORIZED;
+    }
+
+}

--- a/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationService.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationService.java
@@ -5,4 +5,6 @@ import rx.Observable;
 public interface AuthenticationService {
 
     Observable<String> getAccessToken();
+
+    void invalidateAccessToken();
 }

--- a/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationService.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/AuthenticationService.java
@@ -4,7 +4,7 @@ import rx.Observable;
 
 public interface AuthenticationService {
 
-    Observable<String> getAccessToken();
+    Observable<String> retrieveAccessToken();
 
     void invalidateAccessToken();
 }

--- a/core/src/main/java/jackszm/androiddevtweets/api/TwitterApi.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/TwitterApi.java
@@ -26,7 +26,7 @@ public class TwitterApi {
     }
 
     public Observable<String> getAndroidDevTweets() {
-        return authenticationService.getAccessToken()
+        return authenticationService.retrieveAccessToken()
                 .map(toRequest())
                 .map(execute())
                 .retryWhen(retryRule.rule());

--- a/core/src/main/java/jackszm/androiddevtweets/api/TwitterApi.java
+++ b/core/src/main/java/jackszm/androiddevtweets/api/TwitterApi.java
@@ -11,25 +11,25 @@ public class TwitterApi {
 
     private final RequestExecutor requestExecutor;
     private final AuthenticationService authenticationService;
-    private final AuthenticationRetryRule retryRule;
+    private final AuthenticationInterceptor interceptor;
 
     public static TwitterApi newInstance(AuthenticationService authenticationService) {
         RequestExecutor requestExecutor = RequestExecutor.newInstance();
-        AuthenticationRetryRule retryRule = new AuthenticationRetryRule(authenticationService);
-        return new TwitterApi(authenticationService, requestExecutor, retryRule);
+        AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationService);
+        return new TwitterApi(authenticationService, requestExecutor, interceptor);
     }
 
-    TwitterApi(AuthenticationService authenticationService, RequestExecutor requestExecutor, AuthenticationRetryRule retryRule) {
+    TwitterApi(AuthenticationService authenticationService, RequestExecutor requestExecutor, AuthenticationInterceptor interceptor) {
         this.authenticationService = authenticationService;
         this.requestExecutor = requestExecutor;
-        this.retryRule = retryRule;
+        this.interceptor = interceptor;
     }
 
     public Observable<String> getAndroidDevTweets() {
         return authenticationService.retrieveAccessToken()
                 .map(toRequest())
                 .map(execute())
-                .retryWhen(retryRule.rule());
+                .retryWhen(interceptor.retryRule());
     }
 
     private Func1<String, Request> toRequest() {

--- a/core/src/test/java/jackszm/androiddevtweets/api/AuthenticationInterceptorShould.java
+++ b/core/src/test/java/jackszm/androiddevtweets/api/AuthenticationInterceptorShould.java
@@ -1,0 +1,143 @@
+package jackszm.androiddevtweets.api;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.observers.TestSubscriber;
+
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AuthenticationInterceptorShould {
+
+    private static final RequestExecutor.HttpException UNAUTHORIZED_EXCEPTION = new RequestExecutor.HttpException(HTTP_UNAUTHORIZED);
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    AuthenticationService authenticationService;
+
+    private AuthenticationInterceptor retryRule;
+
+    @Before
+    public void setUp() throws Exception {
+        retryRule = new AuthenticationInterceptor(authenticationService);
+    }
+
+    @Test
+    public void doesNotRepeatObservable_whenAnyException() {
+        RetryCountErrorObservable errorObservable = anyException();
+        TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+        Observable.create(errorObservable)
+                .retryWhen(retryRule.retryRule())
+                .subscribe(subscriber);
+
+        assertThat(errorObservable.callCount).isEqualTo(1);
+    }
+
+    @Test
+    public void emitsOriginalException_whenAnyException() {
+        RetryCountErrorObservable errorObservable = anyException();
+        TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+        Observable.create(errorObservable)
+                .retryWhen(retryRule.retryRule())
+                .subscribe(subscriber);
+
+        verify(authenticationService, times(0)).invalidateAccessToken();
+    }
+
+    @Test
+    public void repeatsObservable_thenEmitsException_whenUnauthorizedExceptionHappensMoreThanOnce() {
+        RetryCountErrorObservable errorObservable = unAuthorizedException();
+        TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+        Observable.create(errorObservable)
+                .retryWhen(retryRule.retryRule())
+                .subscribe(subscriber);
+
+        assertThat(errorObservable.callCount).isEqualTo(2);
+        assertThat(subscriber.getOnErrorEvents().get(0)).isEqualTo(UNAUTHORIZED_EXCEPTION);
+        assertThat(subscriber.getOnNextEvents()).isEmpty();
+    }
+
+    @Test
+    public void repeatsObservable_andCallsOnNext_whenUnauthorizedExceptionHappensOnce() {
+        UnauthorizedSingleErrorObservable errorObservable = new UnauthorizedSingleErrorObservable();
+        TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+        Observable.create(errorObservable)
+                .retryWhen(retryRule.retryRule())
+                .subscribe(subscriber);
+
+        assertThat(errorObservable.callCount).isEqualTo(2);
+        assertThat(subscriber.getOnErrorEvents()).isEmpty();
+        assertThat(subscriber.getOnNextEvents()).isNotEmpty();
+    }
+
+    @Test
+    public void invalidatesAccessToken_whenUnauthorizedException() {
+        RetryCountErrorObservable errorObservable = unAuthorizedException();
+        TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+        Observable.create(errorObservable)
+                .retryWhen(retryRule.retryRule())
+                .subscribe(subscriber);
+
+        verify(authenticationService).invalidateAccessToken();
+    }
+
+    private RetryCountErrorObservable unAuthorizedException() {
+        return new RetryCountErrorObservable(UNAUTHORIZED_EXCEPTION);
+    }
+
+    private RetryCountErrorObservable anyException() {
+        return new RetryCountErrorObservable(new RuntimeException("Any Exception"));
+    }
+
+    private static class RetryCountErrorObservable implements Observable.OnSubscribe<String> {
+
+        private final Throwable throwable;
+
+        private int callCount = 0;
+
+        private RetryCountErrorObservable(Throwable throwable) {
+            this.throwable = throwable;
+        }
+
+        @Override
+        public void call(Subscriber<? super String> subscriber) {
+            callCount++;
+            subscriber.onError(throwable);
+        }
+    }
+
+    private static class UnauthorizedSingleErrorObservable implements Observable.OnSubscribe<String> {
+
+        private int callCount = 0;
+
+        private UnauthorizedSingleErrorObservable() {
+        }
+
+        @Override
+        public void call(Subscriber<? super String> subscriber) {
+            callCount++;
+            if (callCount == 2) {
+                subscriber.onNext("data");
+                subscriber.onCompleted();
+            } else {
+                subscriber.onError(UNAUTHORIZED_EXCEPTION);
+            }
+        }
+    }
+}

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -8,7 +8,7 @@ buildProperties {
 }
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 25
     buildToolsVersion "23.0.3"
 
     defaultConfig {
@@ -35,8 +35,8 @@ android {
 dependencies {
     compile project(':core')
 
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:25.1.0'
 
     compile 'com.ataulm:rv-tools:1.0.0'
 

--- a/mobile/src/main/java/jackSzm/androiddevtweets/MainActivityPresenter.java
+++ b/mobile/src/main/java/jackSzm/androiddevtweets/MainActivityPresenter.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import java.util.List;
 
 import jackszm.androiddevtweets.api.AccessTokenService;
-import jackszm.androiddevtweets.api.AuthenticationService;
 import jackszm.androiddevtweets.domain.Tweet;
 import jackszm.androiddevtweets.tweets.TweetsService;
 import rx.Scheduler;

--- a/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenService.java
+++ b/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenService.java
@@ -33,16 +33,16 @@ public class AccessTokenService implements AuthenticationService {
     }
 
     @Override
-    public Observable<String> getAccessToken() {
-        return Observable.fromCallable(getCachedAccessToken())
+    public Observable<String> retrieveAccessToken() {
+        return Observable.fromCallable(cachedAccessToken())
                 .flatMap(requestAccessTokenIfNotCached());
     }
 
-    private Callable<Optional<String>> getCachedAccessToken() {
+    private Callable<Optional<String>> cachedAccessToken() {
         return new Callable<Optional<String>>() {
             @Override
             public Optional<String> call() throws Exception {
-                return accessTokenStorage.getCachedAccessToken();
+                return accessTokenStorage.cachedAccessToken();
             }
         };
     }

--- a/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenStorage.java
+++ b/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenStorage.java
@@ -40,4 +40,9 @@ class AccessTokenStorage {
         editor.apply();
     }
 
+    public void invalidateCachedAccessToken() {
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.remove(accessTokenKey);
+        editor.apply();
+    }
 }

--- a/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenStorage.java
+++ b/mobile/src/main/java/jackszm/androiddevtweets/api/AccessTokenStorage.java
@@ -25,7 +25,7 @@ class AccessTokenStorage {
         this.accessTokenKey = accessTokenKey;
     }
 
-    public Optional<String> getCachedAccessToken() {
+    public Optional<String> cachedAccessToken() {
         if (preferences.contains(accessTokenKey)) {
             String accessToken = preferences.getString(accessTokenKey, UNUSED_ACCESS_TOKEN_DEFAULT);
             return Optional.of(accessToken);

--- a/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenServiceShould.java
+++ b/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenServiceShould.java
@@ -76,4 +76,11 @@ public class AccessTokenServiceShould {
         return Observable.just("{\"access_token\": \"" + API_ACCESS_TOKEN + "\"}");
     }
 
+    @Test
+    public void invalidateAccessToken() {
+        accessTokenService.invalidateAccessToken();
+
+        verify(accessTokenStorage).invalidateCachedAccessToken();
+    }
+
 }

--- a/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenServiceShould.java
+++ b/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenServiceShould.java
@@ -43,31 +43,31 @@ public class AccessTokenServiceShould {
 
     @Test
     public void returnCachedAccessToken_whenItIsPresentInTheStorage() {
-        given(accessTokenStorage.getCachedAccessToken()).willReturn(Optional.of(CACHED_ACCESS_TOKEN));
+        given(accessTokenStorage.cachedAccessToken()).willReturn(Optional.of(CACHED_ACCESS_TOKEN));
 
         TestObserver<String> observer = new TestObserver<>();
-        accessTokenService.getAccessToken().subscribe(observer);
+        accessTokenService.retrieveAccessToken().subscribe(observer);
 
         assertThat(observer.getOnNextEvents().get(0)).isEqualTo(CACHED_ACCESS_TOKEN);
     }
 
     @Test
     public void returnAccessTokenFromApi_whenCachedAccessTokenIsAbsent() {
-        given(accessTokenStorage.getCachedAccessToken()).willReturn(Optional.<String>absent());
+        given(accessTokenStorage.cachedAccessToken()).willReturn(Optional.<String>absent());
         given(authenticationApi.getAccessTokenUsing(AUTHORIZATION_KEY)).willReturn(accessTokenResponse());
 
         TestObserver<String> observer = new TestObserver<>();
-        accessTokenService.getAccessToken().subscribe(observer);
+        accessTokenService.retrieveAccessToken().subscribe(observer);
 
         assertThat(observer.getOnNextEvents().get(0)).isEqualTo(API_ACCESS_TOKEN);
     }
 
     @Test
     public void saveApiAccessToken_whenRetrievedFromTheApi() {
-        given(accessTokenStorage.getCachedAccessToken()).willReturn(Optional.<String>absent());
+        given(accessTokenStorage.cachedAccessToken()).willReturn(Optional.<String>absent());
         given(authenticationApi.getAccessTokenUsing(AUTHORIZATION_KEY)).willReturn(accessTokenResponse());
 
-        accessTokenService.getAccessToken().subscribe();
+        accessTokenService.retrieveAccessToken().subscribe();
 
         verify(accessTokenStorage).storeAccessToken(API_ACCESS_TOKEN);
     }

--- a/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenStorageShould.java
+++ b/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenStorageShould.java
@@ -41,7 +41,7 @@ public class AccessTokenStorageShould {
         given(preferences.contains(ACCESS_TOKEN_KEY)).willReturn(true);
         given(preferences.getString(eq(ACCESS_TOKEN_KEY), any(String.class))).willReturn(ACCESS_TOKEN);
 
-        Optional<String> accessToken = accessTokenStorage.getCachedAccessToken();
+        Optional<String> accessToken = accessTokenStorage.cachedAccessToken();
 
         assertThat(accessToken.isPresent()).isTrue();
         assertThat(accessToken.get()).isEqualTo(ACCESS_TOKEN);
@@ -51,7 +51,7 @@ public class AccessTokenStorageShould {
     public void returnNoAccessToken_whenAccessTokenIsMissingInPreferences() {
         given(preferences.contains(ACCESS_TOKEN_KEY)).willReturn(false);
 
-        Optional<String> accessToken = accessTokenStorage.getCachedAccessToken();
+        Optional<String> accessToken = accessTokenStorage.cachedAccessToken();
 
         assertThat(accessToken.isAbsent()).isTrue();
     }

--- a/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenStorageShould.java
+++ b/mobile/src/test/java/jackszm/androiddevtweets/api/AccessTokenStorageShould.java
@@ -71,4 +71,19 @@ public class AccessTokenStorageShould {
         inOrder.verifyNoMoreInteractions();
     }
 
+    @Test
+    public void removeAccessTokenFromPreferences() {
+        SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+        given(preferences.edit()).willReturn(editor);
+        given(editor.putString(anyString(), anyString())).willReturn(editor);
+
+        accessTokenStorage.invalidateCachedAccessToken();
+
+        InOrder inOrder = inOrder(preferences, editor);
+        inOrder.verify(preferences).edit();
+        inOrder.verify(editor).remove(ACCESS_TOKEN_KEY);
+        inOrder.verify(editor).apply();
+        inOrder.verifyNoMoreInteractions();
+
+    }
 }


### PR DESCRIPTION
## Problem

Twitter API calls need to be authenticated with access token. 

## Solution

Token is being invalidated once 401 response is received. Then new token is requested and request repeated. After second 401, error is emitted. 